### PR TITLE
Fix accidentally stateful port calculation.

### DIFF
--- a/start.go
+++ b/start.go
@@ -180,13 +180,9 @@ func basePort(env Env) (int, error) {
 	return defaultPort, nil
 }
 
-func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of *OutletFactory) {
-	port, err := basePort(env)
-	if err != nil {
-		panic(err)
-	}
+func (f *Forego) startProcess(base, idx, procNum int, proc ProcfileEntry, env Env, of *OutletFactory) {
 
-	port = port + (idx * 100)
+	port := base + (idx * 100)
 
 	const interactive = false
 	workDir := filepath.Dir(flagProcfile)
@@ -236,7 +232,7 @@ func (f *Forego) startProcess(idx, procNum int, proc ProcfileEntry, env Env, of 
 		select {
 		case <-finished:
 			if flagRestart {
-				f.startProcess(idx, procNum, proc, env, of)
+				f.startProcess(base, idx, procNum, proc, env, of)
 			} else {
 				f.teardown.Fall()
 			}
@@ -272,6 +268,9 @@ func runStart(cmd *Command, args []string) {
 	handleError(err)
 
 	env, err := loadEnvs(envs)
+	handleError(err)
+
+	base, err := basePort(env)
 	handleError(err)
 
 	of := NewOutletFactory()
@@ -321,7 +320,7 @@ func runStart(cmd *Command, args []string) {
 		}
 		for i := 0; i < numProcs; i++ {
 			if (singleton == "") || (singleton == proc.Name) {
-				f.startProcess(idx, i, proc, env, of)
+				f.startProcess(base, idx, i, proc, env, of)
 			}
 		}
 	}


### PR DESCRIPTION
Before:

forego | starting aaa.1 on port 5000
forego | starting bbb.1 on port 5100
forego | starting ccc.1 on port 5300
forego | starting ddd.1 on port 5600
forego | starting eee.1 on port 6000

After:

forego | starting aaa.1 on port 5000
forego | starting bbb.1 on port 5100
forego | starting ccc.1 on port 5200
forego | starting ddd.1 on port 5300
forego | starting eee.1 on port 5400